### PR TITLE
chore: 버전 단일 소스 (package.json)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# 버전 일치 검사: package.json이 단일 소스
+pkg_version=$(node -p "require('./package.json').version")
+tauri_version=$(node -p "require('./src-tauri/tauri.conf.json').version")
+cargo_version=$(grep '^version' src-tauri/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+if [[ "$pkg_version" != "$tauri_version" || "$pkg_version" != "$cargo_version" ]]; then
+  echo ""
+  echo "⚠️  버전 불일치!"
+  echo "  package.json:    $pkg_version"
+  echo "  tauri.conf.json: $tauri_version"
+  echo "  Cargo.toml:      $cargo_version"
+  echo ""
+  echo "→ pnpm sync-version 으로 동기화하세요"
+  echo ""
+  exit 1
+fi
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "type": "module",
   "scripts": {
     "postinstall": "git config core.hooksPath .githooks",
-    "dev": "tauri dev",
-    "build": "tauri build",
+    "sync-version": "node scripts/sync-version.mjs",
+    "dev": "node scripts/sync-version.mjs && tauri dev",
+    "build": "node scripts/sync-version.mjs && tauri build",
     "dev:vite": "vite",
     "build:vite": "tsc && vite build",
     "lint": "oxlint .",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,0 +1,33 @@
+/**
+ * package.json의 version을 tauri.conf.json과 Cargo.toml에 동기화.
+ * package.json이 단일 소스.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf-8'));
+const version = pkg.version;
+
+// tauri.conf.json
+const tauriConfPath = resolve(root, 'src-tauri/tauri.conf.json');
+const tauriConf = JSON.parse(readFileSync(tauriConfPath, 'utf-8'));
+if (tauriConf.version !== version) {
+  tauriConf.version = version;
+  writeFileSync(tauriConfPath, JSON.stringify(tauriConf, null, 2) + '\n');
+  console.log(`tauri.conf.json: ${tauriConf.version} → ${version}`);
+}
+
+// Cargo.toml
+const cargoPath = resolve(root, 'src-tauri/Cargo.toml');
+const cargo = readFileSync(cargoPath, 'utf-8');
+const updated = cargo.replace(
+  /^version\s*=\s*"[^"]*"/m,
+  `version = "${version}"`,
+);
+if (cargo !== updated) {
+  writeFileSync(cargoPath, updated);
+  console.log(`Cargo.toml: → ${version}`);
+}


### PR DESCRIPTION
## Summary
- package.json이 유일한 버전 소스. tauri.conf.json, Cargo.toml은 자동 동기화
- `pnpm dev` / `pnpm build` 실행 시 자동 sync
- pre-commit 훅으로 불일치 커밋 차단
- `pnpm sync-version`으로 수동 실행 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)