### PR TITLE
refactor: Bounds를 discriminated union으로 리팩토링

### DIFF
--- a/src/renderer/game/target.test.ts
+++ b/src/renderer/game/target.test.ts
@@ -3,14 +3,15 @@ import { describe, expect, it } from 'vitest';
 import { type MonitorRect } from '../../shared/types';
 import { SPRITE_DISPLAY_SIZE } from './constants';
 import {
+  type Bounds,
   clampPositionToBounds,
   generateRandomTarget,
   isPositionInBounds,
 } from './target';
 
 describe('generateRandomTarget', () => {
-  it('should generate position within bounds (no monitor rects)', () => {
-    const bounds = { width: 800, height: 600 };
+  it('should generate position within bounds (single screen)', () => {
+    const bounds: Bounds = { kind: 'single', width: 800, height: 600 };
 
     for (let i = 0; i < 100; i++) {
       const target = generateRandomTarget(bounds);
@@ -23,13 +24,11 @@ describe('generateRandomTarget', () => {
   });
 
   it('should generate position within a monitor rect, not in dead zones', () => {
-    // 두 모니터: 왼쪽(0,0,1280x800), 오른쪽(1280,0,1920x1080)
-    // dead zone: x>=1280 && y>800 (오른쪽 모니터 하단 영역)
     const monitorRects: MonitorRect[] = [
       { x: 0, y: 0, width: 1280, height: 800 },
       { x: 1280, y: 0, width: 1920, height: 1080 },
     ];
-    const bounds = { width: 3200, height: 1080, monitorRects };
+    const bounds: Bounds = { kind: 'multi', monitorRects };
 
     for (let i = 0; i < 200; i++) {
       const target = generateRandomTarget(bounds);
@@ -53,7 +52,7 @@ describe('generateRandomTarget', () => {
     const monitorRects: MonitorRect[] = [
       { x: 100, y: 50, width: 800, height: 600 },
     ];
-    const bounds = { width: 1000, height: 700, monitorRects };
+    const bounds: Bounds = { kind: 'multi', monitorRects };
 
     for (let i = 0; i < 100; i++) {
       const target = generateRandomTarget(bounds);
@@ -67,7 +66,7 @@ describe('generateRandomTarget', () => {
 });
 
 describe('clampPositionToBounds', () => {
-  const bounds = { width: 800, height: 600 };
+  const bounds: Bounds = { kind: 'single', width: 800, height: 600 };
 
   it('should not change position within bounds', () => {
     const position = { x: 100, y: 100 };
@@ -87,24 +86,22 @@ describe('clampPositionToBounds', () => {
 
   it('should clamp x exceeding bounds', () => {
     const result = clampPositionToBounds({ x: 900, y: 100 }, bounds);
-    expect(result.x).toBe(bounds.width - SPRITE_DISPLAY_SIZE);
+    expect(result.x).toBe(800 - SPRITE_DISPLAY_SIZE);
   });
 
   it('should clamp y exceeding bounds', () => {
     const result = clampPositionToBounds({ x: 100, y: 700 }, bounds);
-    expect(result.y).toBe(bounds.height - SPRITE_DISPLAY_SIZE);
+    expect(result.y).toBe(600 - SPRITE_DISPLAY_SIZE);
   });
 
   describe('with staggered monitor rects', () => {
-    // 계단식 배치: 모니터1(0,0), 모니터2(1280,200), 모니터3(2560,400)
     const staggeredRects: MonitorRect[] = [
       { x: 0, y: 0, width: 1280, height: 800 },
       { x: 1280, y: 200, width: 1920, height: 1080 },
       { x: 3200, y: 400, width: 1440, height: 900 },
     ];
-    const staggeredBounds = {
-      width: 4640,
-      height: 1480,
+    const staggeredBounds: Bounds = {
+      kind: 'multi',
       monitorRects: staggeredRects,
     };
 
@@ -119,10 +116,6 @@ describe('clampPositionToBounds', () => {
     });
 
     it('should clamp dead zone position to nearest monitor', () => {
-      // (1400, 150)은 두 번째 모니터 위의 데드존
-      // 모니터1(0,0,1280x800)까지 거리: 120 (x축)
-      // 모니터2(1280,200,1920x1080)까지 거리: 50 (y축)
-      // → 모니터2가 더 가까우므로 y=200으로 클램핑
       const result = clampPositionToBounds(
         { x: 1400, y: 150 },
         staggeredBounds,
@@ -132,7 +125,6 @@ describe('clampPositionToBounds', () => {
     });
 
     it('should clamp position far outside to nearest monitor edge', () => {
-      // (5000, 500)은 세 번째 모니터 오른쪽 바깥
       const result = clampPositionToBounds(
         { x: 5000, y: 500 },
         staggeredBounds,
@@ -142,17 +134,17 @@ describe('clampPositionToBounds', () => {
     });
 
     it('should allow seamless transition between vertically adjacent monitors', () => {
-      // M1(0,0,1280x800)과 M2(1280,200,1920x1080)의 수직 이음새
-      // 스프라이트 중심이 M1에 있으면 → M1에 속함
       const halfSprite = SPRITE_DISPLAY_SIZE / 2;
       const justInM1 = { x: 100, y: 800 - halfSprite - 1 };
-      expect(clampPositionToBounds(justInM1, staggeredBounds)).toEqual(justInM1);
+      expect(clampPositionToBounds(justInM1, staggeredBounds)).toEqual(
+        justInM1,
+      );
     });
   });
 });
 
 describe('isPositionInBounds', () => {
-  const bounds = { width: 800, height: 600 };
+  const bounds: Bounds = { kind: 'single', width: 800, height: 600 };
 
   it('should return true for position inside bounds', () => {
     expect(isPositionInBounds({ x: 100, y: 100 }, bounds)).toBe(true);
@@ -183,9 +175,8 @@ describe('isPositionInBounds', () => {
       { x: 0, y: 0, width: 1280, height: 800 },
       { x: 1280, y: 200, width: 1920, height: 1080 },
     ];
-    const staggeredBounds = {
-      width: 3200,
-      height: 1280,
+    const staggeredBounds: Bounds = {
+      kind: 'multi',
       monitorRects: staggeredRects,
     };
 
@@ -202,14 +193,12 @@ describe('isPositionInBounds', () => {
     });
 
     it('should return false for position in dead zone', () => {
-      // (1400, 0)은 두 번째 모니터 위의 데드존
       expect(isPositionInBounds({ x: 1400, y: 0 }, staggeredBounds)).toBe(
         false,
       );
     });
 
     it('should return false for position below first monitor but left of second', () => {
-      // (100, 850)은 첫 번째 모니터 아래, 두 번째 모니터 왼쪽
       expect(isPositionInBounds({ x: 100, y: 850 }, staggeredBounds)).toBe(
         false,
       );

--- a/src/renderer/game/target.ts
+++ b/src/renderer/game/target.ts
@@ -2,11 +2,22 @@ import { type MonitorRect } from '../../shared/types';
 import { SPRITE_DISPLAY_SIZE } from './constants';
 import { type Position } from './types';
 
-export type Bounds = {
+// === Bounds: 유효 영역의 단일 표현 ===
+
+export type SingleScreenBounds = {
+  readonly kind: 'single';
   readonly width: number;
   readonly height: number;
-  readonly monitorRects?: readonly MonitorRect[];
 };
+
+export type MultiScreenBounds = {
+  readonly kind: 'multi';
+  readonly monitorRects: readonly MonitorRect[];
+};
+
+export type Bounds = SingleScreenBounds | MultiScreenBounds;
+
+// === MonitorRect 헬퍼 (multi 전용) ===
 
 /** 스프라이트 중심점이 모니터 rect 안에 있는지 판정 */
 function isInMonitorRect(position: Position, rect: MonitorRect): boolean {
@@ -39,96 +50,123 @@ function distanceToRect(position: Position, rect: MonitorRect): number {
   return Math.sqrt(dx * dx + dy * dy);
 }
 
-export function generateRandomTarget(bounds: Bounds): Position {
-  if (bounds.monitorRects && bounds.monitorRects.length > 0) {
-    const rects = bounds.monitorRects;
-
-    // 넓이 비례로 모니터 선택 (큰 모니터에 더 자주 가도록)
-    const totalArea = rects.reduce((sum, r) => sum + r.width * r.height, 0);
-    let pick = Math.random() * totalArea;
-    let chosen = rects[0];
-    for (const rect of rects) {
-      pick -= rect.width * rect.height;
-      if (pick <= 0) {
-        chosen = rect;
-        break;
-      }
+/** 가장 가까운 모니터 rect 찾기 */
+function findNearestRect(
+  position: Position,
+  rects: readonly MonitorRect[],
+): MonitorRect {
+  let nearest = rects[0];
+  let minDist = distanceToRect(position, nearest);
+  for (let i = 1; i < rects.length; i++) {
+    const d = distanceToRect(position, rects[i]);
+    if (d < minDist) {
+      minDist = d;
+      nearest = rects[i];
     }
-
-    const maxX = chosen.x + chosen.width - SPRITE_DISPLAY_SIZE;
-    const maxY = chosen.y + chosen.height - SPRITE_DISPLAY_SIZE;
-    const rangeX = Math.max(0, maxX - chosen.x);
-    const rangeY = Math.max(0, maxY - chosen.y);
-
-    return {
-      x: Math.floor(chosen.x + Math.random() * rangeX),
-      y: Math.floor(chosen.y + Math.random() * rangeY),
-    };
   }
-
-  // 폴백: 전체 bounds 사용 (모니터 정보 없을 때)
-  const maxX = bounds.width - SPRITE_DISPLAY_SIZE;
-  const maxY = bounds.height - SPRITE_DISPLAY_SIZE;
-
-  return {
-    x: Math.floor(Math.random() * maxX),
-    y: Math.floor(Math.random() * maxY),
-  };
+  return nearest;
 }
 
-export function clampPositionToBounds(
+// === single 전용 헬퍼 ===
+
+function clampToSingleScreen(
   position: Position,
-  bounds: Bounds,
+  bounds: SingleScreenBounds,
 ): Position {
-  if (bounds.monitorRects && bounds.monitorRects.length > 0) {
-    // 이미 어떤 모니터 안에 있으면 그대로 반환
-    for (const rect of bounds.monitorRects) {
-      if (isInMonitorRect(position, rect)) {
-        return position;
-      }
-    }
-
-    // 가장 가까운 모니터로 클램핑
-    let nearest = bounds.monitorRects[0];
-    let minDist = distanceToRect(position, nearest);
-    for (let i = 1; i < bounds.monitorRects.length; i++) {
-      const d = distanceToRect(position, bounds.monitorRects[i]);
-      if (d < minDist) {
-        minDist = d;
-        nearest = bounds.monitorRects[i];
-      }
-    }
-    return clampToRect(position, nearest);
-  }
-
-  // 폴백: 전체 bounds 사용
   const maxX = bounds.width - SPRITE_DISPLAY_SIZE;
   const maxY = bounds.height - SPRITE_DISPLAY_SIZE;
-
   return {
     x: Math.max(0, Math.min(position.x, maxX)),
     y: Math.max(0, Math.min(position.y, maxY)),
   };
 }
 
+// === 공개 API ===
+
+export function generateRandomTarget(bounds: Bounds): Position {
+  switch (bounds.kind) {
+    case 'multi': {
+      const rects = bounds.monitorRects;
+
+      // 넓이 비례로 모니터 선택 (큰 모니터에 더 자주 가도록)
+      const totalArea = rects.reduce((sum, r) => sum + r.width * r.height, 0);
+      let pick = Math.random() * totalArea;
+      let chosen = rects[0];
+      for (const rect of rects) {
+        pick -= rect.width * rect.height;
+        if (pick <= 0) {
+          chosen = rect;
+          break;
+        }
+      }
+
+      const maxX = chosen.x + chosen.width - SPRITE_DISPLAY_SIZE;
+      const maxY = chosen.y + chosen.height - SPRITE_DISPLAY_SIZE;
+      const rangeX = Math.max(0, maxX - chosen.x);
+      const rangeY = Math.max(0, maxY - chosen.y);
+
+      return {
+        x: Math.floor(chosen.x + Math.random() * rangeX),
+        y: Math.floor(chosen.y + Math.random() * rangeY),
+      };
+    }
+
+    case 'single': {
+      const maxX = bounds.width - SPRITE_DISPLAY_SIZE;
+      const maxY = bounds.height - SPRITE_DISPLAY_SIZE;
+      return {
+        x: Math.floor(Math.random() * maxX),
+        y: Math.floor(Math.random() * maxY),
+      };
+    }
+  }
+}
+
+export function clampPositionToBounds(
+  position: Position,
+  bounds: Bounds,
+): Position {
+  switch (bounds.kind) {
+    case 'multi': {
+      for (const rect of bounds.monitorRects) {
+        if (isInMonitorRect(position, rect)) {
+          return position;
+        }
+      }
+      return clampToRect(
+        position,
+        findNearestRect(position, bounds.monitorRects),
+      );
+    }
+
+    case 'single':
+      return clampToSingleScreen(position, bounds);
+  }
+}
+
 export function isPositionInBounds(
   position: Position,
   bounds: Bounds,
 ): boolean {
-  if (bounds.monitorRects && bounds.monitorRects.length > 0) {
-    return bounds.monitorRects.some((rect) => isInMonitorRect(position, rect));
-  }
+  switch (bounds.kind) {
+    case 'multi':
+      return bounds.monitorRects.some((rect) =>
+        isInMonitorRect(position, rect),
+      );
 
-  return (
-    position.x >= 0 &&
-    position.x <= bounds.width &&
-    position.y >= 0 &&
-    position.y <= bounds.height
-  );
+    case 'single':
+      return (
+        position.x >= 0 &&
+        position.x <= bounds.width &&
+        position.y >= 0 &&
+        position.y <= bounds.height
+      );
+  }
 }
 
-export function getWindowBounds(): Bounds {
+export function getWindowBounds(): SingleScreenBounds {
   return {
+    kind: 'single',
     width: window.innerWidth,
     height: window.innerHeight,
   };

--- a/src/renderer/game/update-movement.test.ts
+++ b/src/renderer/game/update-movement.test.ts
@@ -4,7 +4,7 @@ import { type MovementState } from './types';
 import { startMovement, stopMovement, updateMovement } from './update-movement';
 
 describe('updateMovement', () => {
-  const bounds = { width: 800, height: 600 };
+  const bounds = { kind: 'single' as const, width: 800, height: 600 };
 
   it('should not move when target is null', () => {
     const state: MovementState = {

--- a/src/renderer/game/update.test.ts
+++ b/src/renderer/game/update.test.ts
@@ -59,7 +59,7 @@ function createTestState(
   };
 }
 
-const bounds = { width: 800, height: 600 };
+const bounds = { kind: 'single' as const, width: 800, height: 600 };
 
 describe('update', () => {
   describe('click event', () => {

--- a/src/renderer/hooks/useMaenggu.ts
+++ b/src/renderer/hooks/useMaenggu.ts
@@ -5,7 +5,7 @@ import { type MonitorRect, type SpritePack } from '../../shared/types';
 import { MAX_DELTA_MS } from '../game/constants';
 import { createInitialState } from '../game/create-initial-state';
 import { loadSpritePack } from '../game/sprite-pack';
-import { getWindowBounds } from '../game/target';
+import { type Bounds, getWindowBounds } from '../game/target';
 import {
   type GameAction,
   type GameEvent,
@@ -145,10 +145,11 @@ export function useMaenggu(
       const events = eventsRef.current;
       eventsRef.current = [];
 
-      const bounds = {
-        ...getWindowBounds(),
-        monitorRects: monitorRectsRef.current,
-      };
+      const rects = monitorRectsRef.current;
+      const bounds: Bounds =
+        rects.length > 0
+          ? { kind: 'multi', monitorRects: rects }
+          : getWindowBounds();
 
       // 상태 업데이트 (ref에서 직접 읽어서 setState 중복 호출 문제 회피)
       const result: UpdateResult = update(


### PR DESCRIPTION
## Summary
- `Bounds` 타입을 `{ width, height, monitorRects? }` 에서 `SingleScreenBounds | MultiScreenBounds` discriminated union으로 변경
- 모든 bounds 소비 함수(`generateRandomTarget`, `clampPositionToBounds`, `isPositionInBounds`)에서 `switch(bounds.kind)` 패턴 사용
- `useMaenggu`에서 monitorRects 유무에 따라 올바른 variant 생성
- invalid state(monitorRects 있는데 width/height도 있는)를 컴파일 타임에 차단

## Test plan
- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 0 warnings
- [x] `pnpm test` 98 tests 전체 통과
- [ ] 멀티모니터 환경에서 맹구 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)